### PR TITLE
`Dockerfile`: Separate `composer/composer` image as a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+FROM composer/composer:2.8.9-bin AS composer-bin
+
 FROM php:8.4.7-cli-alpine
 
-COPY --from=composer/composer:2.8.9-bin /composer /usr/local/bin/composer
+COPY --from=composer-bin /composer /usr/local/bin/composer
 
 COPY bin/decode-php-constraint /usr/local/bin/decode-php-constraint
 COPY composer.json composer.lock /app/


### PR DESCRIPTION
So that Dependabot can auto-update it.